### PR TITLE
use urijs to align URL parsing between Node and Chrome

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const protocols = require("protocols")
+var URI = require('urijs');
 
 /**
  * parsePath
@@ -41,21 +41,24 @@ function parsePath(url) {
       , parse_failed: false
     }
 
-    try {
-        const parsed = new URL(url)
-        output.protocols = protocols(parsed)
+    try {        
+        const parsed = URI(url.trim())        
+        output.protocols = parsed.protocol().split(/\:|\+/).filter(Boolean)
+        if (output.protocols.length === 0){
+            throw new TypeError("Invalid URL " + url)
+        }
         output.protocol = output.protocols[0]
-        output.port = parsed.port
-        output.resource =  parsed.hostname
-        output.host =  parsed.host
-        output.user = parsed.username || ""
-        output.password = parsed.password || ""
-        output.pathname = parsed.pathname
-        output.hash = parsed.hash.slice(1)
-        output.search = parsed.search.slice(1)
-        output.href = parsed.href
-        output.query = Object.fromEntries(parsed.searchParams)
-    } catch (e) {
+        output.port = parsed.port()
+        output.resource =  parsed.hostname()
+        output.host =  parsed.host()
+        output.user = parsed.username() || ""
+        output.password = parsed.password() || ""
+        output.pathname = parsed.pathname()
+        output.hash = parsed.hash()?.slice(1) || ""
+        output.search = parsed.search()?.slice(1) || ""
+        output.href = parsed.href()
+        output.query = URI.parseQuery(output.search)
+    } catch (e) {        
         // TODO Maybe check if it is a valid local file path
         //      In any case, these will be parsed by higher
         //      level parsers such as parse-url, git-url-parse, git-up

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tester": "^1.4.5"
   },
   "dependencies": {
-    "protocols": "^2.0.0"
+    "urijs": "^1.19.11"
   },
   "files": [
     "bin/",

--- a/test/index.js
+++ b/test/index.js
@@ -266,9 +266,9 @@ const INPUTS = [
         , resource: "%0aalert(1)"
         , host: "%0aalert(1)"
         , user: ""
-        , pathname: ""
+        , pathname: "/"
         , hash: ""
-        , href: "javascript://%0aalert(1)"
+        , href: "javascript://%0aalert(1)/"
         , query: {}
         , parse_failed: false
         , search: ""


### PR DESCRIPTION
Chrome's URL module uses the WHATWG algorithm which doesn't identify `ssh://` as a proper protocol.
Node's URL module does identify `ssh://`, this results in an inconsistent behavior between Node and browsers with this package.
Using urijs as the standard URL parser will allow web applications to properly use this package.
This fixes https://github.com/IonicaBizau/git-url-parse/issues/153

For similar issues and some more details:
https://github.com/nodejs/node/issues/36172
https://github.com/honkit/honkit/issues/256